### PR TITLE
Update to use the langchain-neo4j package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .env
+.venv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/1-knowledge-graphs-vectors/solutions/create_vector.py
+++ b/1-knowledge-graphs-vectors/solutions/create_vector.py
@@ -7,10 +7,10 @@ from langchain_community.document_loaders import DirectoryLoader, TextLoader
 from langchain.text_splitter import CharacterTextSplitter
 # end::import_splitter[]
 # tag::import_graph[]
-from langchain_community.graphs import Neo4jGraph
+from langchain_neo4j import Neo4jGraph
 # end::import_graph[]
 # tag::import_vector[]
-from langchain_community.vectorstores.neo4j_vector import Neo4jVector
+from langchain_neo4j import Neo4jVector
 from langchain_openai import OpenAIEmbeddings
 # end::import_vector[]
 

--- a/2-llm-rag-python-langchain/chat_agent.py
+++ b/2-llm-rag-python-langchain/chat_agent.py
@@ -9,8 +9,7 @@ from langchain import hub
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain.schema import StrOutputParser
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
-from langchain_community.graphs import Neo4jGraph
+from langchain_neo4j import Neo4jChatMessageHistory, Neo4jGraph
 from uuid import uuid4
 
 SESSION_ID = str(uuid4())

--- a/2-llm-rag-python-langchain/cypher_chain.py
+++ b/2-llm-rag-python-langchain/cypher_chain.py
@@ -3,11 +3,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from langchain_openai import ChatOpenAI
-from langchain_community.graphs import Neo4jGraph
-from langchain.chains import GraphCypherQAChain
+from langchain_neo4j import GraphCypherQAChain, Neo4jGraph
 from langchain.prompts import PromptTemplate
 
-llm = ChatOpenAI(openai_api_key=os.getenv('OPENAI_API_KEY'))
+llm = ChatOpenAI(openai_api_key=os.getenv("OPENAI_API_KEY"), temperature=0.0, seed=1)
 
 graph = Neo4jGraph(
     url=os.getenv('NEO4J_URI'),
@@ -32,7 +31,8 @@ cypher_chain = GraphCypherQAChain.from_llm(
     llm,
     graph=graph,
     cypher_prompt=cypher_generation_prompt,
-    verbose=True
+    verbose=True,
+    allow_dangerous_requests=True,
 )
 
 cypher_chain.invoke({"query": "What is the plot of the movie Toy Story?"})

--- a/2-llm-rag-python-langchain/cypher_chain.py
+++ b/2-llm-rag-python-langchain/cypher_chain.py
@@ -6,7 +6,7 @@ from langchain_openai import ChatOpenAI
 from langchain_neo4j import GraphCypherQAChain, Neo4jGraph
 from langchain.prompts import PromptTemplate
 
-llm = ChatOpenAI(openai_api_key=os.getenv("OPENAI_API_KEY"), temperature=0.0, seed=1)
+llm = ChatOpenAI(openai_api_key=os.getenv('OPENAI_API_KEY'))
 
 graph = Neo4jGraph(
     url=os.getenv('NEO4J_URI'),

--- a/2-llm-rag-python-langchain/llm_chain.py
+++ b/2-llm-rag-python-langchain/llm_chain.py
@@ -4,7 +4,7 @@ load_dotenv()
 
 from langchain_openai import OpenAI
 from langchain.prompts import PromptTemplate
-from langchain.chains import LLMChain
+from langchain.chains.llm import LLMChain
 
 llm = OpenAI(openai_api_key=os.getenv('OPENAI_API_KEY'))
 

--- a/2-llm-rag-python-langchain/query_vector.py
+++ b/2-llm-rag-python-langchain/query_vector.py
@@ -3,8 +3,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from langchain_openai import OpenAIEmbeddings
-from langchain_community.graphs import Neo4jGraph
-from langchain_community.vectorstores import Neo4jVector
+from langchain_neo4j import Neo4jGraph, Neo4jVector
 
 embedding_provider = OpenAIEmbeddings(
     openai_api_key=os.getenv('OPENAI_API_KEY')

--- a/2-llm-rag-python-langchain/retriever_chain.py
+++ b/2-llm-rag-python-langchain/retriever_chain.py
@@ -2,10 +2,9 @@ import os
 from dotenv import load_dotenv
 load_dotenv()
 
-from langchain.chains import RetrievalQA
+from langchain.chains.retrieval_qa.base import RetrievalQA
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from langchain_community.graphs import Neo4jGraph
-from langchain_community.vectorstores import Neo4jVector
+from langchain_neo4j import Neo4jGraph, Neo4jVector
 
 llm = ChatOpenAI(openai_api_key=os.getenv('OPENAI_API_KEY'))
 

--- a/2-llm-rag-python-langchain/solutions/chat_agent.py
+++ b/2-llm-rag-python-langchain/solutions/chat_agent.py
@@ -9,8 +9,7 @@ from langchain import hub
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain.schema import StrOutputParser
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
-from langchain_community.graphs import Neo4jGraph
+from langchain_neo4j import Neo4jChatMessageHistory, Neo4jGraph
 from uuid import uuid4
 
 SESSION_ID = str(uuid4())

--- a/2-llm-rag-python-langchain/solutions/chat_agent_retriever.py
+++ b/2-llm-rag-python-langchain/solutions/chat_agent_retriever.py
@@ -3,7 +3,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from langchain.chains import RetrievalQA
+from langchain.chains.retrieval_qa.base import RetrievalQA
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain.tools import Tool
 from langchain import hub
@@ -11,9 +11,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain.schema import StrOutputParser
 from langchain_community.tools import YouTubeSearchTool
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
-from langchain_community.graphs import Neo4jGraph
-from langchain_community.vectorstores import Neo4jVector
+from langchain_neo4j import Neo4jChatMessageHistory, Neo4jGraph, Neo4jVector
 from uuid import uuid4
 
 SESSION_ID = str(uuid4())

--- a/2-llm-rag-python-langchain/solutions/chat_agent_trailer.py
+++ b/2-llm-rag-python-langchain/solutions/chat_agent_trailer.py
@@ -12,8 +12,7 @@ from langchain.schema import StrOutputParser
 # tag::import-youtube[]
 from langchain_community.tools import YouTubeSearchTool
 # end::import-youtube[]
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
-from langchain_community.graphs import Neo4jGraph
+from langchain_neo4j import Neo4jChatMessageHistory, Neo4jGraph
 from uuid import uuid4
 
 SESSION_ID = str(uuid4())

--- a/2-llm-rag-python-langchain/solutions/chat_model_memory.py
+++ b/2-llm-rag-python-langchain/solutions/chat_model_memory.py
@@ -8,8 +8,7 @@ from langchain.schema import StrOutputParser
 # tag::imports[]
 from langchain_core.prompts import MessagesPlaceholder
 from langchain_core.runnables.history import RunnableWithMessageHistory
-from langchain_community.graphs import Neo4jGraph
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
+from langchain_neo4j import Neo4jChatMessageHistory, Neo4jGraph
 from uuid import uuid4
 # end::imports[]
 # tag::session-id[]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 python-dotenv==1.0.1
 tenacity!=8.4.0
-langchain==0.2.3
-openai==1.33.0
-langchain-openai==0.1.8
-neo4j-driver==5.21.0
-langchainhub==0.1.18
-langchain-community==0.2.4
+langchain==0.3.9
+openai==1.56.0
+langchain-openai==0.2.10
+neo4j==5.27.0
+langchainhub==0.1.21
+langchain-neo4j==0.1.1
+langchain-community==0.3.9
 youtube-search==2.1.2
 colorama==0.4.6


### PR DESCRIPTION
- Adds `langchain-neo4j` to requirements
- Updates all other requirements to their latest version
- Replaces `langchain_community` imports for `Neo4jVector`, `Neo4jGraph`, `Neo4jChatMessageHistory`, `GraphCypherQAChain` with their `langchain_neo4j` equivalents
- Updates various other imports which were failing